### PR TITLE
Laser first approach

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1,18 +1,133 @@
 use crate::solver_node::active_laser::ActiveLaser;
-use crate::solver_node2::SolverNode2;
+use crate::solver_node2::{SolverNode2, SPIRAL_ORDER};
 use crate::token::{Token, TokenType};
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct Checker {
     grid: SolverNode2,
     // there can be 4 active lasers if 2 perpindicular lasers hit the same beam splitter
     active_lasers: [Option<ActiveLaser>; 4],
     laser_visited: [[bool; 4]; 25],
+    unoriented_occupied_cells: Vec<usize>,
 }
 
 impl Checker {
-    pub fn check(self) -> Self {
-        todo!()
+    pub fn check(mut self) -> Self {
+        self.initialize();
+
+        while self.has_active_lasers() {
+            // inner loop: iterate on lasers and do some work on Some()s until no more active lasers
+            let mut new_laser_index = 0;
+            let mut new_lasers = [None, None, None, None];
+            for laser in self.active_lasers.iter_mut().flatten() {
+                // if the laser is still on the board after going to the next position, check for
+                // a token. if there's a token, do the interactions.
+                // panics if more than 3 active lasers. if this happens it's either an invalid puzzle or programming error..
+                if let Some(next_laser_position) = laser.next_position() {
+                    if let Some(token) = &mut self.grid.cells[next_laser_position] {
+                        // check for unoriented token; if we hit an unoriented token, terminate this laser and save the index
+                        if token.orientation().is_none() {
+                            new_laser_index += 1;
+                            self.unoriented_occupied_cells.push(next_laser_position);
+                            continue;
+                        }
+
+                        // if the piece is oriented, continue marching the laser
+                        for new_laser_direction in token
+                            .outbound_lasers_given_inbound_laser_direction(&laser.orientation)
+                            .into_iter()
+                            .flatten()
+                        {
+                            if self.laser_visited[next_laser_position]
+                                [new_laser_direction.to_index()]
+                            {
+                                // println!("Laser is going in a loop!");
+                                continue;
+                            }
+                            self.laser_visited[next_laser_position]
+                                [new_laser_direction.to_index()] = true;
+                            if new_laser_index > 3 {
+                                println!("panic config: {:?}", self);
+                                panic!("laser index > 3!");
+                            }
+                            let new_active_laser = ActiveLaser {
+                                cell_index: next_laser_position,
+                                orientation: new_laser_direction,
+                            };
+                            if !new_lasers
+                                .clone()
+                                .into_iter()
+                                .flatten()
+                                .collect::<Vec<ActiveLaser>>()
+                                .contains(&new_active_laser)
+                            {
+                                new_lasers[new_laser_index] = Some(new_active_laser);
+                                new_laser_index += 1;
+                            }
+                        }
+                    } else {
+                        self.laser_visited[next_laser_position][laser.orientation.to_index()] =
+                            true;
+                        if new_laser_index > 3 {
+                            println!("panic config: {:?}", self);
+                            panic!("laser index > 3!!");
+                        }
+                        new_lasers[new_laser_index] = Some(ActiveLaser {
+                            cell_index: next_laser_position,
+                            orientation: laser.orientation.clone(),
+                        });
+                        new_laser_index += 1;
+                    }
+                }
+            }
+            self.active_lasers = new_lasers;
+        }
+
+        self
+    }
+
+    pub fn generate_branches(mut self) -> Result<[Option<Token>; 25], Vec<SolverNode2>> {
+        // - march the laser forward until no active lasers
+        // - if a laser visits an unoriented token: record the index and terminate that active laser
+        // - if the laser visted unoriented tokens: generate new branches for orienting those pieces
+        // - if the lasers didn't visit unoriented tokens, and not all tokens are placed,
+        //     new branches will be made for placing the next token in any cell the laser visited
+
+        self = self.check();
+        if self.solved() {
+            self.grid.reset_tokens();
+            Ok(self.grid.cells.clone())
+        } else {
+            self.grid.reset_tokens();
+            Err(self.generate_branches_after_check())
+        }
+    }
+
+    fn generate_branches_after_check(&mut self) -> Vec<SolverNode2> {
+        if !self.unoriented_occupied_cells.is_empty() {
+            // if the laser hit an unoriented token, populate the next branches by setting the orientation of that token
+            self.unoriented_occupied_cells
+                .iter()
+                .map(|cell_index| self.grid.generate_orientation_branches_at_cell(*cell_index))
+                .flatten()
+                .collect::<Vec<SolverNode2>>()
+        } else if let Some(token) = self.grid.tokens_to_be_added_shuffled.pop() {
+            // if the laser only hit oriented tokens, try placing the next token in any of the cells the laser visited but are not occupied by a token
+            let empty_cells_with_active_laser = self.empty_cells_with_active_laser();
+            let mut result = vec![];
+            for i in SPIRAL_ORDER.iter() {
+                if !empty_cells_with_active_laser.contains(i) {
+                    continue;
+                }
+                let mut new_node = self.grid.clone();
+                new_node.cells[*i] = Some(token.clone());
+                result.push(new_node);
+            }
+            result
+        } else {
+            // this board isn't solved, and doesn't have any new children
+            vec![]
+        }
     }
 
     pub fn from_solver_node(solver_node: SolverNode2) -> Self {

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1,0 +1,112 @@
+use crate::solver_node::active_laser::ActiveLaser;
+use crate::solver_node2::SolverNode2;
+use crate::token::{Token, TokenType};
+
+#[derive(Clone, Default)]
+pub struct Checker {
+    grid: SolverNode2,
+    // there can be 4 active lasers if 2 perpindicular lasers hit the same beam splitter
+    active_lasers: [Option<ActiveLaser>; 4],
+    laser_visited: [[bool; 4]; 25],
+}
+
+impl Checker {
+    pub fn check(self) -> Self {
+        todo!()
+    }
+
+    pub fn from_solver_node(solver_node: SolverNode2) -> Self {
+        Self {
+            grid: solver_node,
+            ..Default::default()
+        }
+    }
+
+    fn cells_with_active_laser(&self) -> Vec<usize> {
+        let mut result = vec![];
+        for (idx, cell) in self.laser_visited.into_iter().enumerate() {
+            if cell[0] || cell[1] || cell[2] || cell[3] {
+                result.push(idx);
+            }
+        }
+        result
+    }
+
+    // return the indices of cells where the laser has visited but there is no token
+    fn empty_cells_with_active_laser(&self) -> Vec<usize> {
+        let mut result = vec![];
+        for (idx, cell) in self.laser_visited.into_iter().enumerate() {
+            if self.grid.cells[idx].is_none() && (cell[0] || cell[1] || cell[2] || cell[3]) {
+                result.push(idx);
+            }
+        }
+        result
+    }
+
+    fn has_active_lasers(&self) -> bool {
+        self.active_lasers.iter().any(|laser| laser.is_some())
+    }
+
+    pub fn solved(&self) -> bool {
+        self.grid.targets == self.count_lit_targets() && self.all_required_targets_lit()
+    }
+
+    fn count_lit_targets(&self) -> u8 {
+        self.grid
+            .cells
+            .iter()
+            .filter(|cell| {
+                if let Some(token) = cell {
+                    token.target_lit().unwrap_or(false)
+                } else {
+                    false
+                }
+            })
+            .count() as u8
+    }
+
+    fn all_required_targets_lit(&self) -> bool {
+        self.grid
+            .cells
+            .iter()
+            .filter_map(|cell| {
+                if let Some(token) = cell {
+                    if token.must_light() {
+                        Some(
+                            token
+                                .target_lit()
+                                .expect("Only a target should have must_light = true"),
+                        )
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .all(|b| b)
+    }
+
+    // Find the laser piece and set initialize the active laser there
+    fn initialize(&mut self) {
+        for i in 0..25 {
+            if let Some(token) = &self.grid.cells[i] {
+                if token.type_() == &TokenType::Laser {
+                    self.laser_visited[i][token
+                        .orientation()
+                        .expect("Tried running checker on piece without orientation set")
+                        .to_index()] = true;
+                    let initial_active_laser = ActiveLaser {
+                        orientation: token
+                            .orientation()
+                            .expect("Tried running checker on piece without orientation set")
+                            .clone(),
+                        cell_index: i,
+                    };
+                    self.active_lasers[0] = Some(initial_active_laser);
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/src/checker/active_laser.rs
+++ b/src/checker/active_laser.rs
@@ -1,0 +1,46 @@
+use crate::orientation::Orientation;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ActiveLaser {
+    pub cell_index: usize,
+    pub orientation: Orientation,
+}
+
+impl ActiveLaser {
+    pub fn next_position(&self) -> Option<usize> {
+        match self.orientation {
+            // if we're not on the top row, increment index by 5
+            Orientation::North => {
+                if self.cell_index >= 20 {
+                    None
+                } else {
+                    Some(self.cell_index + 5)
+                }
+            }
+            // if we're not on the right column, increment by 1
+            Orientation::East => {
+                if self.cell_index % 5 == 4 {
+                    None
+                } else {
+                    Some(self.cell_index + 1)
+                }
+            }
+            // if we're not on the bottom row, decrement index by 5
+            Orientation::South => {
+                if self.cell_index <= 4 {
+                    None
+                } else {
+                    Some(self.cell_index - 5)
+                }
+            }
+            // if we're not on the left column, decrement by 1
+            Orientation::West => {
+                if self.cell_index % 5 == 0 {
+                    None
+                } else {
+                    Some(self.cell_index - 1)
+                }
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,4 @@
 use std::collections::HashMap;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc, Mutex,
-};
-use std::thread;
 use std::time;
 
 mod orientation;
@@ -17,7 +12,6 @@ mod solver_node2;
 use solver_node2::SolverNode2;
 
 mod checker;
-use checker::Checker;
 
 /// LaserMazeSolver: main struct. initialize this with the puzzle -> run .solve()
 /// initial_grid_config: initially, where the tokens are placed on the grid and their rotation
@@ -26,7 +20,7 @@ use checker::Checker;
 struct LaserMazeSolver {
     initial_grid_config: [Option<Token>; 25],
     tokens_to_be_added: Vec<Token>,
-    dfs_stack: Arc<Mutex<Vec<SolverNode2>>>,
+    stack: Vec<SolverNode2>,
     targets: u8,
 }
 
@@ -45,7 +39,7 @@ impl LaserMazeSolver {
             initial_grid_config,
             tokens_to_be_added,
             targets,
-            dfs_stack: Arc::new(Mutex::new(vec![initial_solver_node])),
+            stack: vec![initial_solver_node],
         }
     }
 
@@ -145,88 +139,18 @@ impl LaserMazeSolver {
     }
 
     #[allow(dead_code)]
-    fn solver_thread(
-        &self,
-        result_found: Arc<AtomicBool>,
-    ) -> thread::JoinHandle<Option<[Option<Token>; 25]>> {
-        let stack = Arc::clone(&self.dfs_stack);
-        thread::spawn(move || {
-            loop {
-                // get the lock on the Mutex, then exit the loop if stack is empty or pop a node
-                let mut vec = stack.lock().unwrap();
-                if vec.is_empty() || result_found.load(Ordering::Acquire) {
-                    break;
-                }
-                let mut node = vec
-                    .pop()
-                    .expect("We just checked that the stack isn't empty");
-
-                // drop the lock on the vec while we do some work
-                drop(vec);
-
-                // build a vec of items to add if we aren't at a leaf
-                // we don't need to clone here, because the nod only gets mutated if it's not a leaf
-                let new_nodes = node.generate_branches();
-
-                if let Some(new_nodes) = new_nodes {
-                    // get the lock back and push the new items
-                    let mut vec = stack.lock().unwrap();
-                    vec.extend(new_nodes);
-                } else {
-                    if node.clone().check().solved() {
-                        result_found.store(true, Ordering::Release);
-                        return Some(node.cells.clone());
-                    }
-                }
-            }
-            None
-        })
-    }
-
-    #[allow(dead_code)]
-    pub fn solve_single_thread(&mut self) -> Option<[Option<Token>; 25]> {
+    pub fn solve(&mut self) -> Option<[Option<Token>; 25]> {
         if !self.validate() {
             panic!("invalid challenge");
         }
 
         self.initialize();
 
-        // get the stack out of the Arc<Mutex<>>
-        let mut stack = self.dfs_stack.lock().unwrap().clone();
-
-        while !stack.is_empty() {
-            let mut node = stack.pop().expect("loop criteria is non-empty vec");
-            let new_nodes = node.generate_branches();
-            if let Some(new_nodes) = new_nodes {
-                stack.extend(new_nodes);
-            } else {
-                if node.clone().check().solved() {
-                    return Some(node.cells.clone());
-                }
-            }
-        }
-
-        None
-    }
-
-    /// returns None if no solution, or a grid of tokens if a solution is found
-    #[allow(dead_code)]
-    pub fn solve_multi_thread(&mut self, n_threads: usize) -> Option<[Option<Token>; 25]> {
-        if !self.validate() {
-            panic!("invalid challenge");
-        }
-
-        self.initialize();
-
-        let result_found = Arc::new(AtomicBool::new(false));
-        let mut threads = vec![];
-        for _ in 0..n_threads {
-            threads.push(self.solver_thread(result_found.clone()));
-        }
-
-        for thread in threads {
-            if let Some(solution) = thread.join().unwrap() {
-                return Some(solution);
+        while !self.stack.is_empty() {
+            let mut node = self.stack.pop().expect("loop criteria is non-empty vec");
+            match node.generate_branches() {
+                Ok(cells) => return Some(cells),
+                Err(new_nodes) => self.stack.extend(new_nodes),
             }
         }
 
@@ -269,7 +193,7 @@ fn main() {
         let mut solver = LaserMazeSolver::new(cells, tokens_to_be_added, 2);
 
         let t0 = time::Instant::now();
-        let _result = solver.solve_multi_thread(16);
+        let _result = solver.solve();
         let t1 = time::Instant::now();
 
         // println!("{:?}", result.unwrap());
@@ -350,9 +274,9 @@ mod test {
             false,
         ));
 
-        let solver = LaserMazeSolver::new(cells, vec![], 3);
-        let mut solver_node = solver.dfs_stack.lock().unwrap();
-        let result = solver_node
+        let mut solver = LaserMazeSolver::new(cells, vec![], 3);
+        let result = solver
+            .stack
             .pop()
             .expect("LaserMazeSolver initializes with a node")
             .check()
@@ -386,7 +310,7 @@ mod test {
         let mut solver = LaserMazeSolver::new(cells, tokens_to_be_added, 2);
 
         let t0 = time::Instant::now();
-        let result = solver.solve_multi_thread(16);
+        let result = solver.solve();
         let t1 = time::Instant::now();
 
         println!("{:?}", result.unwrap());
@@ -394,7 +318,7 @@ mod test {
     }
 
     #[test]
-    fn test_solver_puzzle_25_par() {
+    fn test_solver_puzzle_25() {
         let mut cells: [Option<Token>; 25] = Default::default();
 
         cells[3] = Some(Token::new(TokenType::TargetMirror, None, true));
@@ -414,7 +338,7 @@ mod test {
         let mut solver = LaserMazeSolver::new(cells, tokens_to_be_added, 2);
 
         let t0 = time::Instant::now();
-        let result = solver.solve_multi_thread(1);
+        let result = solver.solve();
         let t1 = time::Instant::now();
 
         println!("{:?}", result.unwrap());
@@ -422,35 +346,7 @@ mod test {
     }
 
     #[test]
-    fn test_solver_puzzle_25_st() {
-        let mut cells: [Option<Token>; 25] = Default::default();
-
-        cells[3] = Some(Token::new(TokenType::TargetMirror, None, true));
-        cells[7] = Some(Token::new(TokenType::Checkpoint, None, false));
-        cells[8] = Some(Token::new(TokenType::BeamSplitter, None, false));
-        cells[20] = Some(Token::new(TokenType::Laser, None, false));
-        cells[23] = Some(Token::new(
-            TokenType::CellBlocker,
-            Some(Orientation::East),
-            false,
-        ));
-
-        let mut tokens_to_be_added = vec![];
-        tokens_to_be_added.push(Token::new(TokenType::TargetMirror, None, true));
-        tokens_to_be_added.push(Token::new(TokenType::DoubleMirror, None, false));
-
-        let mut solver = LaserMazeSolver::new(cells, tokens_to_be_added, 2);
-
-        let t0 = time::Instant::now();
-        let result = solver.solve_single_thread();
-        let t1 = time::Instant::now();
-
-        println!("{:?}", result.unwrap());
-        println!("Processed in {:?}", t1 - t0);
-    }
-
-    #[test]
-    fn test_solver_puzzle_40_st() {
+    fn test_solver_puzzle_40() {
         let mut cells: [Option<Token>; 25] = Default::default();
 
         cells[3] = Some(Token::new(
@@ -484,7 +380,7 @@ mod test {
         let mut solver = LaserMazeSolver::new(cells, tokens_to_be_added, 2);
 
         let t0 = time::Instant::now();
-        let result = solver.solve_single_thread();
+        let result = solver.solve();
         let t1 = time::Instant::now();
 
         println!("{:?}", result.unwrap());
@@ -492,49 +388,7 @@ mod test {
     }
 
     #[test]
-    fn test_solver_puzzle_40_par() {
-        let mut cells: [Option<Token>; 25] = Default::default();
-
-        cells[3] = Some(Token::new(
-            TokenType::TargetMirror,
-            Some(Orientation::North),
-            true,
-        ));
-        cells[9] = Some(Token::new(
-            TokenType::TargetMirror,
-            Some(Orientation::West),
-            true,
-        ));
-        cells[11] = Some(Token::new(
-            TokenType::DoubleMirror,
-            Some(Orientation::North),
-            false,
-        ));
-        cells[17] = Some(Token::new(
-            TokenType::Checkpoint,
-            Some(Orientation::North),
-            false,
-        ));
-        cells[20] = Some(Token::new(TokenType::Laser, None, false));
-
-        let mut tokens_to_be_added = vec![];
-        tokens_to_be_added.push(Token::new(TokenType::TargetMirror, None, false));
-        tokens_to_be_added.push(Token::new(TokenType::TargetMirror, None, false));
-        tokens_to_be_added.push(Token::new(TokenType::TargetMirror, None, false));
-        tokens_to_be_added.push(Token::new(TokenType::BeamSplitter, None, false));
-
-        let mut solver = LaserMazeSolver::new(cells, tokens_to_be_added, 2);
-
-        let t0 = time::Instant::now();
-        let result = solver.solve_multi_thread(16);
-        let t1 = time::Instant::now();
-
-        println!("{:?}", result.unwrap());
-        println!("Processed in {:?}", t1 - t0);
-    }
-
-    #[test]
-    fn test_solver_puzzle_50_st() {
+    fn test_solver_puzzle_50() {
         let mut cells: [Option<Token>; 25] = Default::default();
 
         cells[3] = Some(Token::new(
@@ -565,7 +419,7 @@ mod test {
         let mut solver = LaserMazeSolver::new(cells, tokens_to_be_added, 3);
 
         let t0 = time::Instant::now();
-        let result = solver.solve_single_thread();
+        let result = solver.solve();
         let t1 = time::Instant::now();
 
         println!("{:?}", result.unwrap());
@@ -573,7 +427,7 @@ mod test {
     }
 
     #[test]
-    fn test_solver_puzzle_55_st() {
+    fn test_solver_puzzle_55() {
         let mut cells: [Option<Token>; 25] = Default::default();
 
         cells[2] = Some(Token::new(TokenType::TargetMirror, None, false));
@@ -591,7 +445,7 @@ mod test {
         let mut solver = LaserMazeSolver::new(cells, tokens_to_be_added, 2);
 
         let t0 = time::Instant::now();
-        let result = solver.solve_single_thread();
+        let result = solver.solve();
         let t1 = time::Instant::now();
 
         println!("{:?}", result.unwrap());
@@ -599,7 +453,7 @@ mod test {
     }
 
     #[test]
-    fn test_solver_puzzle_59_st() {
+    fn test_solver_puzzle_59() {
         let mut cells: [Option<Token>; 25] = Default::default();
 
         cells[6] = Some(Token::new(
@@ -627,7 +481,7 @@ mod test {
         let mut solver = LaserMazeSolver::new(cells, tokens_to_be_added, 3);
 
         let t0 = time::Instant::now();
-        let result = solver.solve_single_thread();
+        let result = solver.solve();
         let t1 = time::Instant::now();
 
         println!("{:?}", result.unwrap());
@@ -635,7 +489,7 @@ mod test {
     }
 
     #[test]
-    fn test_solver_puzzle_60_st() {
+    fn test_solver_puzzle_60() {
         let mut cells: [Option<Token>; 25] = Default::default();
 
         cells[9] = Some(Token::new(
@@ -671,39 +525,10 @@ mod test {
         let mut solver = LaserMazeSolver::new(cells, tokens_to_be_added, 3);
 
         let t0 = time::Instant::now();
-        let result = solver.solve_single_thread();
+        let result = solver.solve();
         let t1 = time::Instant::now();
 
         println!("{:?}", result.unwrap());
         println!("Processed in {:?}", t1 - t0);
     }
-
-    // commented because it takes too long
-    // #[test]
-    // fn test_solver_puzzle_60_par() {
-    //     let mut cells: [Option<Token>; 25] = Default::default();
-
-    //     cells[9] = Some(Token::new(TokenType::TargetMirror, Some(Orientation::North), true));
-    //     cells[23] = Some(Token::new(TokenType::TargetMirror, Some(Orientation::West), true));
-    //     cells[15] = Some(Token::new(TokenType::TargetMirror, Some(Orientation::South), false));
-    //     cells[1] = Some(Token::new(TokenType::DoubleMirror, None, false));
-    //     cells[12] = Some(Token::new(TokenType::Checkpoint, None, false));
-    //     cells[11] = Some(Token::new(TokenType::CellBlocker, Some(Orientation::South), false));
-
-    //     let mut tokens_to_be_added = vec![];
-    //     tokens_to_be_added.push(Token::new(TokenType::Laser, None, false));
-    //     tokens_to_be_added.push(Token::new(TokenType::BeamSplitter, None, false));
-    //     tokens_to_be_added.push(Token::new(TokenType::BeamSplitter, None, false));
-    //     tokens_to_be_added.push(Token::new(TokenType::TargetMirror, None, false));
-    //     tokens_to_be_added.push(Token::new(TokenType::TargetMirror, None, false));
-
-    //     let mut solver = LaserMazeSolver::new(cells, tokens_to_be_added, 3);
-
-    //     let t0 = time::Instant::now();
-    //     let result = solver.solve_multi_thread(16);
-    //     let t1 = time::Instant::now();
-
-    //     println!("{:?}", result.unwrap());
-    //     println!("Processed in {:?}", t1 - t0);
-    // }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -426,6 +426,41 @@ mod test {
         println!("Processed in {:?}", t1 - t0);
     }
 
+    // 2nd to last puzzle with the laser's position not given
+    #[test]
+    fn test_solver_puzzle_54() {
+        let mut cells: [Option<Token>; 25] = Default::default();
+
+        cells[3] = Some(Token::new(TokenType::TargetMirror, None, false));
+        cells[6] = Some(Token::new(
+            TokenType::TargetMirror,
+            Some(Orientation::North),
+            true,
+        ));
+        cells[12] = Some(Token::new(
+            TokenType::TargetMirror,
+            Some(Orientation::South),
+            true,
+        ));
+        cells[18] = Some(Token::new(TokenType::DoubleMirror, None, false));
+        cells[21] = Some(Token::new(TokenType::BeamSplitter, None, false));
+        cells[24] = Some(Token::new(TokenType::TargetMirror, None, false));
+
+        let mut tokens_to_be_added = vec![];
+        tokens_to_be_added.push(Token::new(TokenType::Laser, None, false));
+        tokens_to_be_added.push(Token::new(TokenType::TargetMirror, None, false));
+        tokens_to_be_added.push(Token::new(TokenType::BeamSplitter, None, false));
+
+        let mut solver = LaserMazeSolver::new(cells, tokens_to_be_added, 3);
+
+        let t0 = time::Instant::now();
+        let result = solver.solve();
+        let t1 = time::Instant::now();
+
+        println!("{:?}", result.unwrap());
+        println!("Processed in {:?}", t1 - t0);
+    }
+
     #[test]
     fn test_solver_puzzle_55() {
         let mut cells: [Option<Token>; 25] = Default::default();

--- a/src/solver_node2.rs
+++ b/src/solver_node2.rs
@@ -1,23 +1,22 @@
-use crate::{
-    orientation::Orientation,
-    token::{Token, TokenType},
-};
-pub mod active_laser;
-use active_laser::ActiveLaser;
+use crate::checker::Checker;
+use crate::orientation::Orientation;
+use crate::token::{Token, TokenType};
 use lazy_static::lazy_static;
 
-#[derive(Clone, Default, Debug)]
-pub struct SolverNode {
-    cells: [Option<Token>; 25],
-    tokens_to_be_added: Vec<Token>,
-    tokens_to_be_added_shuffled: Vec<Token>,
-    laser_visited: [[bool; 4]; 25],
-    // there can be 4 active lasers if 2 perpindicular lasers hit the same beam splitter
-    active_lasers: [Option<ActiveLaser>; 4],
-    targets: u8,
+#[derive(Clone, Default)]
+pub struct SolverNode2 {
+    pub cells: [Option<Token>; 25],
+    pub tokens_to_be_added: Vec<Token>,
+    pub tokens_to_be_added_shuffled: Vec<Token>,
+    pub targets: u8,
 }
 
-impl SolverNode {
+impl SolverNode2 {
+    // returns a None if this is truly a leaf
+    pub fn generate_branches(&mut self) -> Option<Vec<Self>> {
+        todo!()
+    }
+
     pub fn new(
         initial_grid_config: [Option<Token>; 25],
         tokens_to_be_added: Vec<Token>,
@@ -31,27 +30,8 @@ impl SolverNode {
         }
     }
 
-    pub fn generate_branches(&mut self) -> Vec<Self> {
-        if !self.laser_placed() {
-            // the laser will be sorted to be at the top of the vec, so this will place the laser
-            return self.generate_token_placement_branches();
-        }
-        if !self.all_placed_tokens_have_orientation_set() {
-            // if not all pieces on the grid have their rotation set, we want to set them first
-            return self.generate_rotation_setting_branches();
-        }
-        // now, we have the laser placed and all orientations of pieces on the board set
-        // next, we need to shuffle the pieces to be added
-        if !self.tokens_to_be_added.is_empty() {
-            return self.generate_shuffled_tokens_to_be_added_branches();
-        }
-        if !self.tokens_to_be_added_shuffled.is_empty() {
-            // we now need to place pieces on the grid such that they interact with the laser
-            return self.generate_token_placement_branches_laser_aware();
-        }
-
-        // if we reach this point, we are at a leaf
-        vec![]
+    fn clone_to_checker(&self) -> Checker {
+        Checker::from_solver_node(self.clone())
     }
 
     fn laser_placed(&self) -> bool {
@@ -214,66 +194,6 @@ impl SolverNode {
         result
     }
 
-    fn cells_with_active_laser(&self) -> Vec<usize> {
-        let mut result = vec![];
-        for (idx, cell) in self.laser_visited.into_iter().enumerate() {
-            if cell[0] || cell[1] || cell[2] || cell[3] {
-                result.push(idx);
-            }
-        }
-        result
-    }
-
-    // return the indices of cells where the laser has visited but there is no token
-    fn empty_cells_with_active_laser(&self) -> Vec<usize> {
-        let mut result = vec![];
-        for (idx, cell) in self.laser_visited.into_iter().enumerate() {
-            if self.cells[idx].is_none() && (cell[0] || cell[1] || cell[2] || cell[3]) {
-                result.push(idx);
-            }
-        }
-        result
-    }
-
-    fn generate_token_placement_branches_laser_aware(&mut self) -> Vec<Self> {
-        // this function will make a copy of the node and march the laser forward, get a list of indices with the laser over it but no token present,
-        // and create nodes with the next token to be placed in each of those locations
-        // orientation will get set next time we go back to generate_branches_laser_aware()!
-        let mut result = vec![];
-
-        if let Some(token) = self.tokens_to_be_added_shuffled.pop() {
-            let empty_cells_with_active_laser =
-                self.clone().check().empty_cells_with_active_laser();
-            for i in SPIRAL_ORDER.iter() {
-                if !empty_cells_with_active_laser.contains(i) {
-                    continue;
-                }
-                let mut new_node = self.clone();
-                new_node.cells[*i] = Some(token.clone());
-                result.push(new_node)
-            }
-        }
-
-        result
-    }
-
-    // in contrast to generate_token_placement_branches_laser_aware, place the next token to be added in any available cell
-    fn generate_token_placement_branches(&mut self) -> Vec<Self> {
-        if let Some(token) = self.tokens_to_be_added.pop() {
-            let mut result = vec![];
-            for i in SPIRAL_ORDER.iter() {
-                if self.cells[*i].is_none() {
-                    let mut new_node = self.clone();
-                    new_node.cells[*i] = Some(token.clone());
-                    result.push(new_node)
-                }
-            }
-            result
-        } else {
-            vec![]
-        }
-    }
-
     // for generating rotation branches, which rotations are valid?
     fn orientation_iter(&self, token_type: &TokenType, cell_index: usize) -> Vec<usize> {
         let mut result = token_type.orientation_range();
@@ -346,167 +266,6 @@ impl SolverNode {
         }
 
         result
-    }
-
-    fn generate_rotation_setting_branches(&mut self) -> Vec<Self> {
-        for i in SPIRAL_ORDER.iter() {
-            if let Some(token) = &self.cells[*i] {
-                if token.orientation().is_none() {
-                    let mut result = vec![];
-                    let mut orientation_iter = self.orientation_iter(token.type_(), *i);
-                    if orientation_iter.is_empty() {
-                        println!("WARNING: Found a token with no valid orientations. We'll make a dummy node that uses Some(North). This should be optimized out.");
-                        orientation_iter.push(0);
-                    }
-                    for x in orientation_iter {
-                        let mut new_node = self.clone();
-                        new_node.cells[*i]
-                            .as_mut()
-                            .expect("We just validated there is a token in this cell")
-                            .orientation = Some(Orientation::from_index(x));
-                        result.push(new_node);
-                    }
-                    return result;
-                }
-            }
-        }
-
-        vec![]
-    }
-
-    pub fn clone_cells(&self) -> [Option<Token>; 25] {
-        self.cells.clone()
-    }
-
-    fn has_active_lasers(&self) -> bool {
-        self.active_lasers.iter().any(|laser| laser.is_some())
-    }
-
-    pub fn check(mut self) -> Self {
-        self.initialize();
-
-        // outer loop: keep cranking the laser states until there are no more lasers
-        while self.has_active_lasers() {
-            // inner loop: iterate on lasers and do some work on Some()s until no more active lasers
-            let mut new_laser_index = 0;
-            let mut new_lasers = [None, None, None, None];
-            for laser in self.active_lasers.iter_mut().flatten() {
-                // if the laser is still on the board after going to the next position, check for
-                // a token. if there's a token, do the interactions.
-                // panics if more than 3 active lasers. if this happens it's either an invalid puzzle or programming error..
-                if let Some(next_laser_position) = laser.next_position() {
-                    if let Some(token) = &mut self.cells[next_laser_position] {
-                        for new_laser_direction in token
-                            .outbound_lasers_given_inbound_laser_direction(&laser.orientation)
-                            .into_iter()
-                            .flatten()
-                        {
-                            if self.laser_visited[next_laser_position]
-                                [new_laser_direction.to_index()]
-                            {
-                                continue;
-                            }
-                            self.laser_visited[next_laser_position]
-                                [new_laser_direction.to_index()] = true;
-                            if new_laser_index > 3 {
-                                println!("panic config: {:?}", self);
-                                panic!("laser index > 3!");
-                            }
-                            let new_active_laser = ActiveLaser {
-                                cell_index: next_laser_position,
-                                orientation: new_laser_direction,
-                            };
-                            if !new_lasers
-                                .clone()
-                                .into_iter()
-                                .flatten()
-                                .collect::<Vec<ActiveLaser>>()
-                                .contains(&new_active_laser)
-                            {
-                                new_lasers[new_laser_index] = Some(new_active_laser);
-                                new_laser_index += 1;
-                            }
-                        }
-                    } else {
-                        self.laser_visited[next_laser_position][laser.orientation.to_index()] =
-                            true;
-                        if new_laser_index > 3 {
-                            println!("panic config: {:?}", self);
-                            panic!("laser index > 3!!");
-                        }
-                        new_lasers[new_laser_index] = Some(ActiveLaser {
-                            cell_index: next_laser_position,
-                            orientation: laser.orientation.clone(),
-                        });
-                        new_laser_index += 1;
-                    }
-                }
-            }
-            self.active_lasers = new_lasers;
-        }
-
-        self
-    }
-
-    pub fn solved(&self) -> bool {
-        self.targets == self.count_lit_targets() && self.all_required_targets_lit()
-    }
-
-    fn count_lit_targets(&self) -> u8 {
-        self.cells
-            .iter()
-            .filter(|cell| {
-                if let Some(token) = cell {
-                    token.target_lit().unwrap_or(false)
-                } else {
-                    false
-                }
-            })
-            .count() as u8
-    }
-
-    fn all_required_targets_lit(&self) -> bool {
-        self.cells
-            .iter()
-            .filter_map(|cell| {
-                if let Some(token) = cell {
-                    if token.must_light() {
-                        Some(
-                            token
-                                .target_lit()
-                                .expect("Only a target should have must_light = true"),
-                        )
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            })
-            .all(|b| b)
-    }
-
-    // Find the laser piece and set initialize the active laser there
-    fn initialize(&mut self) {
-        for i in 0..25 {
-            if let Some(token) = &self.cells[i] {
-                if token.type_() == &TokenType::Laser {
-                    self.laser_visited[i][token
-                        .orientation()
-                        .expect("Tried running checker on piece without orientation set")
-                        .to_index()] = true;
-                    let initial_active_laser = ActiveLaser {
-                        orientation: token
-                            .orientation()
-                            .expect("Tried running checker on piece without orientation set")
-                            .clone(),
-                        cell_index: i,
-                    };
-                    self.active_lasers[0] = Some(initial_active_laser);
-                    return;
-                }
-            }
-        }
     }
 
     // returns an array representing the out-of-board orientations
@@ -616,6 +375,11 @@ impl SolverNode {
 
         [None, None]
     }
+
+    pub fn check(self) -> Checker {
+        let mut checker = self.clone_to_checker();
+        checker.check()
+    }
 }
 
 lazy_static! {
@@ -643,51 +407,4 @@ lazy_static! {
 
 lazy_static! {
     static ref WEST_EDGE_CELL_INDICES: [usize; 3] = [5, 10, 15,];
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use std::mem;
-
-    #[test]
-    fn mem_sizes() {
-        let solver_node = mem::size_of::<SolverNode>();
-        println!("SolverNode has size {solver_node}");
-    }
-
-    #[test]
-    fn test_edge_detect() {
-        // test cell blocker on top right corner
-        let mut cells: [Option<Token>; 25] = Default::default();
-        cells[24] = Some(Token::new(TokenType::CellBlocker, None, false));
-        let solver = SolverNode::new(cells, vec![], 1);
-        assert_eq!(
-            [Some(Orientation::North), Some(Orientation::East)],
-            solver.forbidden_orientations(19)
-        );
-        // test piece away from cell blocker or edge
-        assert_eq!([None, None], solver.forbidden_orientations(18));
-        // test piece on edge
-        assert_eq!(
-            [Some(Orientation::West), None],
-            solver.forbidden_orientations(10)
-        );
-        // test piece on corner
-        assert_eq!(
-            [Some(Orientation::South), Some(Orientation::West)],
-            solver.forbidden_orientations(0)
-        );
-        // test center
-        assert_eq!([None, None], solver.forbidden_orientations(12));
-
-        // test cell blocker on non-corner edge with piece neighboring
-        let mut cells: [Option<Token>; 25] = Default::default();
-        cells[3] = Some(Token::new(TokenType::CellBlocker, None, false));
-        let solver = SolverNode::new(cells, vec![], 1);
-        assert_eq!(
-            [Some(Orientation::South), None],
-            solver.forbidden_orientations(8)
-        );
-    }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -36,6 +36,13 @@ impl Token {
         }
     }
 
+    pub fn reset(&mut self) {
+        self.lit = false;
+        if self.target_lit.is_some() {
+            self.target_lit = Some(false);
+        }
+    }
+
     // getter for private field
     pub fn type_(&self) -> &TokenType {
         &self.type_


### PR DESCRIPTION
Puzzle 60 (laser position not given) was taking 20s to solve, while puzzle 59 (laser position given) was only taking ~ 200 ms, despite their similar complexity (1.4B permutations for puzzle 60 and 1.2B for puzzle 59). This is because the previous approach brute forced all grid arrangements for the tokens already on the grid + the laser iteself.

The new laser-first approach sidesteps this problem by only setting orientation on pieces the laser actually interacts with. Upon visiting an unoriented token, the laser terminates, and we generate new nodes with the unoriented token's orientation set to any valid orientation. Therefore, unviable laser placements don't need to check every permutation of the other tokens on the grid which don't have an orientation set.

This also provides some speed gains to puzzles where the laser's position is given.

| Puzzle # | Time (old) | Time (new) |
| :----:   | :----:     | :----:     |
| 59       | 240.167 ms | 13.166 ms  |
| 60       | 19.06 s    | 3.481 s    |

I also ripped out the parallel implementation here because it sucks.