### PR TITLE
2 splitters 2 targets fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,7 +1251,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "laser-mazer"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "eframe",
  "egui_extras",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laser-mazer"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -272,7 +272,7 @@ mod test {
         let result = solver.solve();
         let t1 = time::Instant::now();
 
-        println!("{:?}", result.unwrap());
+        println!("{:?}", result.unwrap().unwrap());
         println!("Processed in {:?}", t1 - t0);
     }
 
@@ -300,7 +300,7 @@ mod test {
         let result = solver.solve();
         let t1 = time::Instant::now();
 
-        println!("{:?}", result.unwrap());
+        println!("{:?}", result.unwrap().unwrap());
         println!("Processed in {:?}", t1 - t0);
     }
 
@@ -342,7 +342,7 @@ mod test {
         let result = solver.solve();
         let t1 = time::Instant::now();
 
-        println!("{:?}", result.unwrap());
+        println!("{:?}", result.unwrap().unwrap());
         println!("Processed in {:?}", t1 - t0);
     }
 
@@ -381,7 +381,7 @@ mod test {
         let result = solver.solve();
         let t1 = time::Instant::now();
 
-        println!("{:?}", result.unwrap());
+        println!("{:?}", result.unwrap().unwrap());
         println!("Processed in {:?}", t1 - t0);
     }
 
@@ -442,7 +442,7 @@ mod test {
         let result = solver.solve();
         let t1 = time::Instant::now();
 
-        println!("{:?}", result.unwrap());
+        println!("{:?}", result.unwrap().unwrap());
         println!("Processed in {:?}", t1 - t0);
     }
 
@@ -478,7 +478,7 @@ mod test {
         let result = solver.solve();
         let t1 = time::Instant::now();
 
-        println!("{:?}", result.unwrap());
+        println!("{:?}", result.unwrap().unwrap());
         println!("Processed in {:?}", t1 - t0);
     }
 
@@ -522,7 +522,7 @@ mod test {
         let result = solver.solve();
         let t1 = time::Instant::now();
 
-        println!("{:?}", result.unwrap());
+        println!("{:?}", result.unwrap().unwrap());
         println!("Processed in {:?}", t1 - t0);
     }
 
@@ -571,7 +571,7 @@ mod test {
         let result = solver.solve();
         let t1 = time::Instant::now();
 
-        println!("{:?}", result.unwrap());
+        println!("{:?}", result.unwrap().unwrap());
         println!("Processed in {:?}", t1 - t0);
     }
 
@@ -649,7 +649,7 @@ mod test {
         let result = solver.solve();
         let t1 = time::Instant::now();
 
-        println!("{:?}", result.unwrap());
+        println!("{:?}", result.unwrap().unwrap());
         println!("Processed in {:?}", t1 - t0);
     }
 

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -652,8 +652,10 @@ mod test {
         let result = solver.solve();
         match result {
             Ok(_) => panic!("Test failed, should error"),
-            Err(s) => assert_eq!(s, String::from("Invalid piece count for piece type TargetMirror!")),
+            Err(s) => assert_eq!(
+                s,
+                String::from("Invalid piece count for piece type TargetMirror!")
+            ),
         }
-
     }
 }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -634,11 +634,26 @@ mod test {
 
     #[test]
     fn no_laser() {
-        let mut solver = LaserMazeSolver::new(Default::default(), vec![], 1);
+        // Include a TargetMirror in the test so that we get the error about the laser instead
+        let tokens_to_add = vec![Token::new(TokenType::TargetMirror, None, false)];
+        let mut solver = LaserMazeSolver::new(Default::default(), tokens_to_add, 1);
         let result = solver.solve();
         match result {
             Ok(_) => panic!("Test failed, should error"),
             Err(s) => assert_eq!(s, String::from("Invalid piece count for piece type Laser!")),
         }
+    }
+
+    #[test]
+    fn no_target_mirror() {
+        // Include a Laser in the test so that we get the error about the laser instead
+        let tokens_to_add = vec![Token::new(TokenType::Laser, None, false)];
+        let mut solver = LaserMazeSolver::new(Default::default(), tokens_to_add, 1);
+        let result = solver.solve();
+        match result {
+            Ok(_) => panic!("Test failed, should error"),
+            Err(s) => assert_eq!(s, String::from("Invalid piece count for piece type TargetMirror!")),
+        }
+
     }
 }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -579,32 +579,15 @@ mod test {
     fn test_solver_puzzle_62() {
         // Bonus Challenge 2
         let mut cells: [Option<Token>; 25] = Default::default();
-        cells[0] = Some(Token::new(
-            TokenType::TargetMirror,
-            None,
-            false,
-        ));
-        cells[11] = Some(Token::new(
-            TokenType::Laser,
-            None,
-            false,
-        ));
-        cells[14] = Some(Token::new(
-            TokenType::DoubleMirror,
-            None,
-            false,
-        ));
+        cells[0] = Some(Token::new(TokenType::TargetMirror, None, false));
+        cells[11] = Some(Token::new(TokenType::Laser, None, false));
+        cells[14] = Some(Token::new(TokenType::DoubleMirror, None, false));
         cells[17] = Some(Token::new(
             TokenType::Checkpoint,
             Some(Orientation::East),
             false,
         ));
-        cells[22] = Some(Token::new(
-            TokenType::TargetMirror,
-            None,
-            false,
-        ));
-
+        cells[22] = Some(Token::new(TokenType::TargetMirror, None, false));
 
         let mut tokens_to_be_added = vec![];
         tokens_to_be_added.push(Token::new(TokenType::TargetMirror, None, false));
@@ -615,14 +598,13 @@ mod test {
 
         let mut solver = LaserMazeSolver::new(cells, tokens_to_be_added, 2);
 
-
         let t0 = time::Instant::now();
         let result = solver.solve();
         let t1 = time::Instant::now();
 
         let solution = result.unwrap().unwrap();
         println!("{:?}", solution);
-        println!("Processed in {:?}", t1 - t0);       
+        println!("Processed in {:?}", t1 - t0);
 
         let split_1 = solution[13].clone().unwrap();
         let split_2 = solution[18].clone().unwrap();

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -575,6 +575,62 @@ mod test {
         println!("Processed in {:?}", t1 - t0);
     }
 
+    #[test]
+    fn test_solver_puzzle_62() {
+        // Bonus Challenge 2
+        let mut cells: [Option<Token>; 25] = Default::default();
+        cells[0] = Some(Token::new(
+            TokenType::TargetMirror,
+            None,
+            false,
+        ));
+        cells[11] = Some(Token::new(
+            TokenType::Laser,
+            None,
+            false,
+        ));
+        cells[14] = Some(Token::new(
+            TokenType::DoubleMirror,
+            None,
+            false,
+        ));
+        cells[17] = Some(Token::new(
+            TokenType::Checkpoint,
+            Some(Orientation::East),
+            false,
+        ));
+        cells[22] = Some(Token::new(
+            TokenType::TargetMirror,
+            None,
+            false,
+        ));
+
+
+        let mut tokens_to_be_added = vec![];
+        tokens_to_be_added.push(Token::new(TokenType::TargetMirror, None, false));
+        tokens_to_be_added.push(Token::new(TokenType::TargetMirror, None, false));
+        tokens_to_be_added.push(Token::new(TokenType::TargetMirror, None, false));
+        tokens_to_be_added.push(Token::new(TokenType::BeamSplitter, None, false));
+        tokens_to_be_added.push(Token::new(TokenType::BeamSplitter, None, false));
+
+        let mut solver = LaserMazeSolver::new(cells, tokens_to_be_added, 2);
+
+
+        let t0 = time::Instant::now();
+        let result = solver.solve();
+        let t1 = time::Instant::now();
+
+        let solution = result.unwrap().unwrap();
+        println!("{:?}", solution);
+        println!("Processed in {:?}", t1 - t0);       
+
+        let split_1 = solution[13].clone().unwrap();
+        let split_2 = solution[18].clone().unwrap();
+
+        assert_eq!(split_1.type_(), &TokenType::BeamSplitter);
+        assert_eq!(split_2.type_(), &TokenType::BeamSplitter);
+    }
+
     // bonus 99
     #[test]
     fn test_solver_puzzle_159() {

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -111,42 +111,11 @@ impl LaserMazeSolver {
         Ok(())
     }
 
-    // initialize some things (for now, just sort the pieces to be added heuristically)
-    fn initialize(&mut self) {
-        // sort the tokens to be added
-        // we will get tokens out of the "to be added vec" with pop so we will sort with the
-        // tokens we want to place first at the end of the vec
-        let reference_order = [
-            // CellBlocker is not allowed in to_be_added, but is here for completeness
-            TokenType::CellBlocker,
-            // the last 3 are ordered by gut feel (for now)
-            TokenType::DoubleMirror,
-            TokenType::BeamSplitter,
-            // the first 3 have more heuristics
-            TokenType::Checkpoint,
-            TokenType::TargetMirror,
-            TokenType::Laser,
-        ];
-        let mut new_tokens = vec![];
-
-        for token_type in reference_order {
-            for token in &self.tokens_to_be_added {
-                if token.type_() == &token_type {
-                    new_tokens.push(token.clone());
-                }
-            }
-        }
-
-        self.tokens_to_be_added = new_tokens;
-    }
-
     #[allow(dead_code)]
     pub fn solve(&mut self) -> Result<Option<[Option<Token>; 25]>, String> {
         // Returns Ok(Some(_)) if solution found, Ok(None) if no solution, Err(s) if
         // invalid puzzle provided; s describes why the puzzle is invalid
         self.validate()?;
-
-        self.initialize();
 
         while let Some(mut node) = self.stack.pop() {
             match node.generate_branches() {

--- a/src/solver/checker.rs
+++ b/src/solver/checker.rs
@@ -349,4 +349,54 @@ mod test {
         assert!(checker.remaining_tokens_to_be_added());
         assert!(!checker.solved());
     }
+
+    #[test]
+    fn test_checker_simple() {
+        let node = SolverNode {
+            cells: [
+                Some(Token::new(TokenType::Laser, Some(Orientation::East), false)),
+                Some(Token::new(
+                    TokenType::BeamSplitter,
+                    Some(Orientation::West),
+                    false,
+                )),
+                Some(Token::new(
+                    TokenType::TargetMirror,
+                    Some(Orientation::West),
+                    false,
+                )),
+                None,
+                None,
+                None,
+                Some(Token::new(
+                    TokenType::TargetMirror,
+                    Some(Orientation::South),
+                    false,
+                )),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            ],
+            tokens_to_be_added: vec![],
+            tokens_to_be_added_shuffled: vec![],
+            targets: 2,
+        };
+        let checker = node.check();
+        assert!(checker.solved());
+    }
 }

--- a/src/solver/solver_node.rs
+++ b/src/solver/solver_node.rs
@@ -469,6 +469,24 @@ impl SolverNode {
         let checker = self.clone_to_checker();
         checker.check()
     }
+
+    // Count all tokens of a certain type associated with the solver node
+    #[allow(unused)]
+    pub fn count_tokens(&self, type_: TokenType) -> usize {
+        let mut count = self.cells.iter().flatten().fold(0, |acc, token| {
+            acc + if token.type_() == &type_ { 1 } else { 0 }
+        });
+        count += self.tokens_to_be_added.iter().fold(0, |acc, token| {
+            acc + if token.type_() == &type_ { 1 } else { 0 }
+        });
+        count += self
+            .tokens_to_be_added_shuffled
+            .iter()
+            .fold(0, |acc, token| {
+                acc + if token.type_() == &type_ { 1 } else { 0 }
+            });
+        count
+    }
 }
 
 lazy_static! {

--- a/src/solver/token.rs
+++ b/src/solver/token.rs
@@ -11,6 +11,18 @@ pub struct Token {
     must_light: bool,
 }
 
+#[derive(Debug, Clone)]
+pub enum LaserTokenInteractionResult {
+    // The laser interacts and is re-emitted
+    OutboundLaser(Orientation),
+    // The laser interacts and is not re-emitted.
+    // `valid` indicates if it's a valid result (with regards to the puzzle),
+    // i.e., a target mirror absorbs the laser, or a token only emits one laser,
+    // or if it's an invalid result
+    // i.e. the laser is hitting the wrong side of a Checkpoint token
+    NoOutboundLaser { valid: bool },
+}
+
 impl Token {
     pub fn new(type_: TokenType, orientation: Option<Orientation>, must_light: bool) -> Self {
         let must_light = if type_ == TokenType::TargetMirror {
@@ -67,7 +79,7 @@ impl Token {
     pub fn outbound_lasers_given_inbound_laser_direction(
         &mut self,
         laser_inbound_orientation: &Orientation,
-    ) -> [Option<Orientation>; 2] {
+    ) -> [LaserTokenInteractionResult; 2] {
         let reoriented_direction = self
             .orientation
             .as_mut()
@@ -75,15 +87,22 @@ impl Token {
             .reorient_inbound_laser(laser_inbound_orientation);
         let reoriented_outbound_lasers =
             self.reference_outbound_lasers_given_inbound_laser_direction(reoriented_direction);
-        let mut outbound_lasers = [None, None];
+        // initialize array with some defaults that we'll overwrite
+        let mut outbound_lasers = [
+            LaserTokenInteractionResult::NoOutboundLaser { valid: false },
+            LaserTokenInteractionResult::NoOutboundLaser { valid: false },
+        ];
         for i in 0..2 {
-            if let Some(laser) = &reoriented_outbound_lasers[i] {
-                outbound_lasers[i] = Some(
-                    self.orientation
-                        .as_ref()
-                        .expect("Called check() with tokens still not having orientation set")
-                        .reorient_outbound_laser(laser),
-                );
+            outbound_lasers[i] = match &reoriented_outbound_lasers[i] {
+                LaserTokenInteractionResult::OutboundLaser(laser) => {
+                    LaserTokenInteractionResult::OutboundLaser(
+                        self.orientation
+                            .as_ref()
+                            .expect("Called check() with tokens still not having orientation set")
+                            .reorient_outbound_laser(laser),
+                    )
+                }
+                x => x.clone(),
             }
         }
 
@@ -95,42 +114,47 @@ impl Token {
     fn reference_outbound_lasers_given_inbound_laser_direction(
         &mut self,
         laser_inbound_orientation: Orientation,
-    ) -> [Option<Orientation>; 2] {
-        match self.type_ {
-            TokenType::Laser => [Some(Orientation::North), None],
+    ) -> [LaserTokenInteractionResult; 2] {
+        type R = LaserTokenInteractionResult;
+        const NONE_VALID: R = R::NoOutboundLaser { valid: true };
+        const NONE_INVALID: R = R::NoOutboundLaser { valid: false };
 
+        match self.type_ {
+            // TODO this should depend on if it's the source of the laser..
+            // TokenType::Laser => [R::OutboundLaser(Orientation::North), NONE_VALID],
+            TokenType::Laser => todo!("The laser needs some work"),
             TokenType::Checkpoint => match laser_inbound_orientation {
                 Orientation::North | Orientation::South => {
                     self.lit = true;
-                    [Some(laser_inbound_orientation), None]
+                    [R::OutboundLaser(laser_inbound_orientation), NONE_VALID]
                 }
-                Orientation::West | Orientation::East => [None, None],
+                Orientation::West | Orientation::East => [NONE_INVALID, NONE_INVALID],
             },
 
             TokenType::TargetMirror => {
                 self.lit = true;
                 match laser_inbound_orientation {
-                    Orientation::North => [Some(Orientation::West), None],
-                    Orientation::West => [None, None],
+                    Orientation::North => [R::OutboundLaser(Orientation::West), NONE_VALID],
+                    Orientation::West => [NONE_INVALID, NONE_INVALID],
                     Orientation::South => {
                         self.target_lit = Some(true);
-                        [None, None]
+                        [NONE_VALID, NONE_VALID]
                     }
-                    Orientation::East => [Some(Orientation::South), None],
+                    Orientation::East => [R::OutboundLaser(Orientation::South), NONE_VALID],
                 }
             }
 
             TokenType::DoubleMirror => {
                 self.lit = true;
                 match laser_inbound_orientation {
-                    Orientation::North => [Some(Orientation::West), None],
-                    Orientation::West => [Some(Orientation::North), None],
-                    Orientation::South => [Some(Orientation::East), None],
-                    Orientation::East => [Some(Orientation::South), None],
+                    Orientation::North => [R::OutboundLaser(Orientation::West), NONE_VALID],
+                    Orientation::West => [R::OutboundLaser(Orientation::North), NONE_VALID],
+                    Orientation::South => [R::OutboundLaser(Orientation::East), NONE_VALID],
+                    Orientation::East => [R::OutboundLaser(Orientation::South), NONE_VALID],
                 }
             }
 
-            TokenType::CellBlocker => [Some(laser_inbound_orientation), None],
+            TokenType::CellBlocker => [R::OutboundLaser(laser_inbound_orientation), NONE_VALID],
 
             TokenType::BeamSplitter => {
                 self.lit = true;
@@ -138,18 +162,22 @@ impl Token {
                     // this piece is the only one to return two beams
                     // in this match statement, the item[0] acts just like the blue double mirror piece
                     // while item[1] is the transmitted beam
-                    Orientation::North => {
-                        [Some(Orientation::West), Some(laser_inbound_orientation)]
-                    }
-                    Orientation::West => {
-                        [Some(Orientation::North), Some(laser_inbound_orientation)]
-                    }
-                    Orientation::South => {
-                        [Some(Orientation::East), Some(laser_inbound_orientation)]
-                    }
-                    Orientation::East => {
-                        [Some(Orientation::South), Some(laser_inbound_orientation)]
-                    }
+                    Orientation::North => [
+                        R::OutboundLaser(Orientation::West),
+                        R::OutboundLaser(laser_inbound_orientation),
+                    ],
+                    Orientation::West => [
+                        R::OutboundLaser(Orientation::North),
+                        R::OutboundLaser(laser_inbound_orientation),
+                    ],
+                    Orientation::South => [
+                        R::OutboundLaser(Orientation::East),
+                        R::OutboundLaser(laser_inbound_orientation),
+                    ],
+                    Orientation::East => [
+                        R::OutboundLaser(Orientation::South),
+                        R::OutboundLaser(laser_inbound_orientation),
+                    ],
                 }
             }
         }

--- a/src/solver/token.rs
+++ b/src/solver/token.rs
@@ -120,9 +120,14 @@ impl Token {
         const NONE_INVALID: R = R::NoOutboundLaser { valid: false };
 
         match self.type_ {
-            // TODO this should depend on if it's the source of the laser..
-            // TokenType::Laser => [R::OutboundLaser(Orientation::North), NONE_VALID],
-            TokenType::Laser => todo!("The laser needs some work"),
+            TokenType::Laser => {
+                match laser_inbound_orientation {
+                    // The laser is shining back into the laser source
+                    Orientation::South => [NONE_VALID, NONE_VALID],
+                    // The laser is returning to the laser token on a wall-side of the laser
+                    _ => [NONE_INVALID, NONE_INVALID],
+                }
+            }
             TokenType::Checkpoint => match laser_inbound_orientation {
                 Orientation::North | Orientation::South => {
                     self.lit = true;


### PR DESCRIPTION
- Lasers going off the board are a fail criteria; lasers striking a token on an invalid side (for example, the plain side of a Target Mirror purple token) are also a fail criteria. Details of this are captured in a new enum `LaserTokenInteractionResult`.
    - Addresses #4 
- Some test fixes - puzzles should have a solution!